### PR TITLE
Bug fix

### DIFF
--- a/src/infrastructure/mongo_article_repository.rs
+++ b/src/infrastructure/mongo_article_repository.rs
@@ -83,12 +83,9 @@ impl ArticleRepository for MongodbArticleRepository {
         title: Option<String>,
         content: Option<String>,
     ) -> Result<Article, ArticleServiceError> {
-        let filter = doc! {
-            "_id": bson::to_bson(&id).unwrap(),
-            "update_at": bson::to_bson(&Utc::now()).unwrap()
-        };
+        let filter = doc! { "_id": bson::to_bson(&id).unwrap() };
 
-        let mut set_doc = doc! {};
+        let mut set_doc = doc! { "updated_at": bson::to_bson(&Utc::now()).unwrap() };
         if let Some(new_title) = title {
             set_doc.insert("title", new_title);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,7 @@ where
 
 #[cfg(test)]
 mod api_test {
+    use axum::http::StatusCode;
     use axum_test::TestServer;
     use dotenvy::dotenv;
 
@@ -197,7 +198,7 @@ mod api_test {
         );
 
         //記事の一部を更新
-        let modified_article = server
+        let article_modifing_response = server
             .patch(&format!(
                 "http://localhost:3000/api/articles/{}",
                 python_waruguchi_article.id
@@ -205,8 +206,9 @@ mod api_test {
             .json(&serde_json::json!({
                 "title": "Pythonは💩"
             }))
-            .await
-            .json::<Article>();
+            .await;
+        assert_eq!(article_modifing_response.status_code(), StatusCode::OK);
+        let modified_article = article_modifing_response.json::<Article>();
         assert_eq!(modified_article.title, "Pythonは💩");
 
         // 新規記事作成テスト
@@ -220,6 +222,14 @@ mod api_test {
             .json(&new_article)
             .await;
         assert_eq!(post_response.status_code(), 201);
+
+        
+        let articles = server
+            .get("http://localhost:3000/api/articles")
+            .await
+            .json::<Vec<Article>>();
+        // もう一度記事一覧が取得できることを確認
+        assert!(!articles.is_empty());
     }
     #[tokio::test]
     async fn user_test() {


### PR DESCRIPTION
MongoDBの `$currentDate` は bsonのDate型を用い、bsonのDate型は `chrono::DateTime` とシリアライズ結果が異なる為、アップデート後のデータをデシリアライズ出来ないというバグがあった。そこで、一先ず MongoDB の `$currentDate` を使うのをやめて、 `Utc::now()` をシリアライズすることにした。今後、bsonのDate型を使うことにするのはありかも知れない。

また、`MongodbArtcileRepository` と `MongodbUserRepositiory` の `collection` フィールドの型をそれぞれ、 `Collection<Article>` `Collection<User>` に変えた。これにより多少、型安全性が上がりコードがシンプルになった。

さらに、今回のバグが修正できたことを確認する為のテストコードの追加を行った。