### PR TITLE
リファクタリング

### DIFF
--- a/src/domain/models/article.rs
+++ b/src/domain/models/article.rs
@@ -30,49 +30,27 @@ impl Article {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Default, Hash)]
-pub struct ArticleId {
-    inner: ObjectId,
-}
+#[derive(Clone, Copy, PartialEq, Eq, Default, Hash, Serialize, Deserialize)]
+pub struct ArticleId(ObjectId);
 
 impl ArticleId {
     pub fn new() -> Self {
-        Self {
-            inner: ObjectId::new(),
-        }
+        Self(ObjectId::new())
     }
     pub fn parse_str(s: &str) -> Result<Self, bson::oid::Error> {
-        ObjectId::parse_str(s).map(|inner| ArticleId { inner })
+        ObjectId::parse_str(s).map(|inner| ArticleId(inner))
     }
 }
 
 impl Debug for ArticleId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("ArticleId")
-            .field(&self.inner.to_hex())
+            .field(&self.0.to_hex())
             .finish()
     }
 }
 impl Display for ArticleId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.inner.to_hex())
-    }
-}
-
-impl Serialize for ArticleId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.inner.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for ArticleId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        ObjectId::deserialize(deserializer).map(|inner| Self { inner })
+        f.write_str(&self.0.to_hex())
     }
 }

--- a/src/domain/models/user.rs
+++ b/src/domain/models/user.rs
@@ -31,45 +31,23 @@ impl AuthUser for User {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Copy, Hash, Default)]
-pub struct UserId {
-    inner: ObjectId,
-}
+#[derive(PartialEq, Eq, Clone, Copy, Hash, Default, Serialize, Deserialize)]
+pub struct UserId(ObjectId);
 
 impl UserId {
     pub fn new() -> Self {
-        Self {
-            inner: ObjectId::new(),
-        }
-    }
-}
-
-impl Serialize for UserId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.inner.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for UserId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        ObjectId::deserialize(deserializer).map(|inner| Self { inner })
+        Self(ObjectId::new())
     }
 }
 
 impl Debug for UserId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("UserId").field(&self.inner.to_hex()).finish()
+        f.debug_tuple("UserId").field(&self.0.to_hex()).finish()
     }
 }
 
 impl Display for UserId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.inner.to_hex())
+        f.write_str(&self.0.to_hex())
     }
 }


### PR DESCRIPTION
`()` を `struct` と共に用いる定義の仕方では、`derive` の方法でbsonにシリアライズした時に、中身とシリアライズ結果が変わらないようなので、定義の仕方を変更し、コード量を削減した。